### PR TITLE
Fix NoSuchMethodError in Android 6 devices

### DIFF
--- a/core/src/main/java/com/stylingandroid/muselee/connectivity/ConnectivityMonitor.kt
+++ b/core/src/main/java/com/stylingandroid/muselee/connectivity/ConnectivityMonitor.kt
@@ -79,7 +79,7 @@ internal sealed class ConnectivityMonitor(
         fun getInstance(context: Context): ConnectivityMonitor {
             val connectivityManager =
                 context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 NougatConnectivityMonitor(connectivityManager)
             } else {
                 LegacyConnectivityMonitor(context, connectivityManager)


### PR DESCRIPTION
There is a problem on line 82, it allows to use `NougatConnectivityMonitor` in Android M devices.